### PR TITLE
Updated dependencies versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,17 @@ An extended abstract of this work (https://arxiv.org/abs/2011.04789) appears in 
 
 ## Development
 
-*pip install pytest*
+This package requires python>=3.8. Install the dependencies with
 
-When run the test files, first in the repo directory.
+ - xargs -L 1 pip install < requirements.txt
 
-- pip3 install -r requirements.txt
+This command installs the dependencies in a specific order.
 
-Go to the test directory ('cd test'), run the following:
+Run the tests with:
+- cd test
 - python -m pytest
 
-
-The OPE scheme is from the open source (https://github.com/tonyo/pyope).
- It implements the OPE scheme by Boldyreva et. al. The source code is place in the 'third-party/ope/' directory.
- We also leverage the partially homomorphic encryption scheme
- (Paillier Cryptosystem: https://en.wikipedia.org/wiki/Paillier_cryptosystem), run __pip install phe__ to
- install this.
+This package depends on the Paillier partially homomorphic encryption scheme (https://en.wikipedia.org/wiki/Paillier_cryptosystem). It also includes source code for a modified version of Boldyreva et. al.'s order-preserving encryption scheme (https://github.com/tonyo/pyope). The source code is place in the 'third-party/ope/' directory.
 
 See [DEVELOPMENT.md](./DEVELOPMENT.md)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,13 @@
 cython==0.29.26
-pandas==0.25.3
+cffi
+numpy>=1.21
+pandas==1.3.5
 phe==1.4.0
+pybind11
+scipy==1.7.1
+scikit-learn==1.0.2
 xgboost==0.90
-numpy==1.17.4
-scipy==1.5.4
-scikit-learn==0.21.3
-flask==1.1.1
-pytest==5.1.2
-third-party/ope
+flask==2.0.2
+pytest==6.2.5
+./third-party/ope
 -e .


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR updates the `numpy` version to `>=1.21`, which fixes a CVE in `numpy`. I've also added several other (indirect) dependencies which should prevent dependencies from failing to install. Finally, I've updated the installation instructions to ensure that dependencies are installed in a specific order, which avoids some installation errors.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
